### PR TITLE
Add Html support

### DIFF
--- a/demo/App.fs
+++ b/demo/App.fs
@@ -16,7 +16,7 @@ type Model =
     | ConfirmToastAlertDocs
     | Other
 
-let init() = SimpleAlertDocs, Cmd.none
+let init () = SimpleAlertDocs, Cmd.none
 
 type AppMsg =
     | SwitchToSimpleAlertDocs
@@ -27,6 +27,7 @@ type AppMsg =
     | SwitchToConfirmToastAlertDocs
     | SimplestAlert
     | SimpleAlertWithTitle
+    | SimpleAlertWithHtml
     | SuccessAlert
     | Timeout
     | HideConfirm
@@ -43,25 +44,19 @@ type AppMsg =
     | SelectAlertMsg
     | SelectAlertConfirmed of (string * string)
 
-let update msg state  =
+let update msg state =
     match msg with
-    | SwitchToSimpleAlertDocs ->
-        SimpleAlertDocs, Cmd.none
+    | SwitchToSimpleAlertDocs -> SimpleAlertDocs, Cmd.none
 
-    | SwitchToToastAlertDocs ->
-        ToastAlertDocs, Cmd.none
+    | SwitchToToastAlertDocs -> ToastAlertDocs, Cmd.none
 
-    | SwitchToConfirmAlertDocs ->
-        ConfirmAlertDocs, Cmd.none
+    | SwitchToConfirmAlertDocs -> ConfirmAlertDocs, Cmd.none
 
-    | SwitchToInputAlertDocs ->
-        InputAlertDocs, Cmd.none
+    | SwitchToInputAlertDocs -> InputAlertDocs, Cmd.none
 
-    | SwitchToSelectAlertDocs ->
-        SelectAlertDocs, Cmd.none
+    | SwitchToSelectAlertDocs -> SelectAlertDocs, Cmd.none
 
-    | SwitchToConfirmToastAlertDocs ->
-        ConfirmToastAlertDocs, Cmd.none
+    | SwitchToConfirmToastAlertDocs -> ConfirmToastAlertDocs, Cmd.none
 
     | SimplestAlert ->
         let alert = SimpleAlert("Simple but sweet")
@@ -69,6 +64,10 @@ let update msg state  =
 
     | SimpleAlertWithTitle ->
         let alert = SimpleAlert("Is that still a thing?").Title("The Internet")
+        state, SweetAlert.Run(alert)
+
+    | SimpleAlertWithHtml ->
+        let alert = SimpleAlert("").Html("<h1 style='color: red'>Simple but sweet</h1>")
         state, SweetAlert.Run(alert)
 
     | SuccessAlert ->
@@ -130,9 +129,7 @@ let update msg state  =
         state, SweetAlert.Run(alert)
 
     | ScrollbarPaddingFalse ->
-        let alert =
-            SimpleAlert("A simple alert without padding")
-                .ScrollbarPadding(false)
+        let alert = SimpleAlert("A simple alert without padding").ScrollbarPadding(false)
 
         state, SweetAlert.Run(alert)
 
@@ -146,15 +143,16 @@ let update msg state  =
         state, SweetAlert.Run(toastAlert)
 
     | ConfirmAlertMsg ->
-        let handleConfirm = function
-        | ConfirmAlertResult.Confirmed -> AppMsg.ConfirmResultMsg (Ok "You confirmed")
-        | ConfirmAlertResult.Dismissed reason ->
-            match reason with
-            | DismissalReason.Cancel -> AppMsg.ConfirmResultMsg (Error "Clicked cancel")
-            | DismissalReason.Close -> AppMsg.ConfirmResultMsg (Error "Clicked close button")
-            | DismissalReason.PressedEscape -> AppMsg.ConfirmResultMsg (Error "Pressed escape")
-            | DismissalReason.TimedOut -> AppMsg.ConfirmResultMsg (Error "Modal closed after timeout")
-            | DismissalReason.ClickedOutsideDialog ->  AppMsg.ConfirmResultMsg (Error "Clicked outside dialog")
+        let handleConfirm =
+            function
+            | ConfirmAlertResult.Confirmed -> AppMsg.ConfirmResultMsg(Ok "You confirmed")
+            | ConfirmAlertResult.Dismissed reason ->
+                match reason with
+                | DismissalReason.Cancel -> AppMsg.ConfirmResultMsg(Error "Clicked cancel")
+                | DismissalReason.Close -> AppMsg.ConfirmResultMsg(Error "Clicked close button")
+                | DismissalReason.PressedEscape -> AppMsg.ConfirmResultMsg(Error "Pressed escape")
+                | DismissalReason.TimedOut -> AppMsg.ConfirmResultMsg(Error "Modal closed after timeout")
+                | DismissalReason.ClickedOutsideDialog -> AppMsg.ConfirmResultMsg(Error "Clicked outside dialog")
 
         let confirmAlert =
             ConfirmAlert("You won't be able to undo this action", handleConfirm)
@@ -166,9 +164,10 @@ let update msg state  =
         state, SweetAlert.Run(confirmAlert)
 
     | ConfirmToastAlertMsg ->
-        let handleConfirm = function
-        | ConfirmAlertResult.Confirmed -> AppMsg.ConfirmResultMsg (Ok "You confirmed")
-        | ConfirmAlertResult.Dismissed reason -> AppMsg.ConfirmResultMsg (Error "Dismissed")
+        let handleConfirm =
+            function
+            | ConfirmAlertResult.Confirmed -> AppMsg.ConfirmResultMsg(Ok "You confirmed")
+            | ConfirmAlertResult.Dismissed reason -> AppMsg.ConfirmResultMsg(Error "Dismissed")
 
         let confirmAlert =
             ConfirmToastAlert("You won't be able to undo this action", handleConfirm)
@@ -197,19 +196,21 @@ let update msg state  =
 
     | InputAlertMsg ->
         let validate input =
-            if String.IsNullOrEmpty input
-            then Error "Input name cannot be empty"
-            else Ok input
+            if String.IsNullOrEmpty input then
+                Error "Input name cannot be empty"
+            else
+                Ok input
 
-        let handleInput = function
-        | InputAlertResult.Confirmed input -> AppMsg.InputResultMsg (Ok input)
-        | InputAlertResult.Dismissed reason ->
-            match reason with
-            | DismissalReason.Cancel -> AppMsg.InputResultMsg (Error "Clicked cancel")
-            | DismissalReason.Close -> AppMsg.InputResultMsg (Error "Clicked close button")
-            | DismissalReason.PressedEscape -> AppMsg.InputResultMsg (Error "Pressed escape")
-            | DismissalReason.TimedOut -> AppMsg.InputResultMsg (Error "Modal closed after timeout")
-            | DismissalReason.ClickedOutsideDialog ->  AppMsg.InputResultMsg (Error "Clicked outside dialog")
+        let handleInput =
+            function
+            | InputAlertResult.Confirmed input -> AppMsg.InputResultMsg(Ok input)
+            | InputAlertResult.Dismissed reason ->
+                match reason with
+                | DismissalReason.Cancel -> AppMsg.InputResultMsg(Error "Clicked cancel")
+                | DismissalReason.Close -> AppMsg.InputResultMsg(Error "Clicked close button")
+                | DismissalReason.PressedEscape -> AppMsg.InputResultMsg(Error "Pressed escape")
+                | DismissalReason.TimedOut -> AppMsg.InputResultMsg(Error "Modal closed after timeout")
+                | DismissalReason.ClickedOutsideDialog -> AppMsg.InputResultMsg(Error "Clicked outside dialog")
 
         let inputAlert =
             InputAlert(handleInput)
@@ -232,18 +233,20 @@ let update msg state  =
     | SelectAlertMsg ->
 
         let options =
-            [  "coffee", "Coffee Driven Development"
-               "domain", "Domain Driven Developement"
-               "test", "Test Driven Developement" ]
+            [ "coffee", "Coffee Driven Development"
+              "domain", "Domain Driven Developement"
+              "test", "Test Driven Developement" ]
             |> Map.ofList
 
-        let validate = function
+        let validate =
+            function
             | (key, value) when key <> "coffee" -> Error "Nope"
-            | (key, value) -> Ok (key, value)
+            | (key, value) -> Ok(key, value)
 
-        let handleInput = function
-        | SelectAlertResult.Confirmed (key, value) -> AppMsg.SelectAlertConfirmed (key, value)
-        | SelectAlertResult.Dismissed reason -> AppMsg.InputResultMsg (Error "Dismissed")
+        let handleInput =
+            function
+            | SelectAlertResult.Confirmed (key, value) -> AppMsg.SelectAlertConfirmed(key, value)
+            | SelectAlertResult.Dismissed reason -> AppMsg.InputResultMsg(Error "Dismissed")
 
         let alert =
             SelectAlert(options, handleInput)
@@ -257,19 +260,29 @@ let update msg state  =
         let alert = SimpleAlert("Everyone loves " + value).Type(AlertType.Success)
         state, SweetAlert.Run(alert)
 
-let simplestAlert = """
+let simplestAlert =
+    """
 | SimplestAlert ->
     let alert = SimpleAlert("Simple but sweet")
     state, SweetAlert.Run(alert)
 """
 
-let simplestAlertWithTitle = """
+let simplestAlertWithTitle =
+    """
 | SimpleAlertWithTitle ->
     let alert = SimpleAlert("Is that still a thing?").Title("The Internet")
     state, SweetAlert.Run(alert)
 """
 
-let successAlert = """
+let simplestAlertWithHtml =
+    """
+| SimplestAlert ->
+    let alert = SimpleAlert("").Html("<h1 style="color: red">Simple but sweet</h1>")
+    state, SweetAlert.Run(alert)
+"""
+
+let successAlert =
+    """
 | SuccessAlert ->
     let successAlert =
         SimpleAlert("Your account has been succesfully created!")
@@ -279,7 +292,8 @@ let successAlert = """
     state, SweetAlert.Run(successAlert)
 """
 
-let selectAlertMsg = """
+let selectAlertMsg =
+    """
 | SelectAlertMsg ->
 
     let options =
@@ -309,7 +323,8 @@ let selectAlertMsg = """
     state, SweetAlert.Run(alert)
 """
 
-let hideConfirm = """
+let hideConfirm =
+    """
 | HideConfirm ->
     let successAlert =
         SimpleAlert("You have levelled up!")
@@ -321,7 +336,8 @@ let hideConfirm = """
     state, SweetAlert.Run(successAlert)
 """
 
-let timeout = """
+let timeout =
+    """
 | Timeout ->
     let errorAlert =
         SimpleAlert("That didn't go as we expected")
@@ -332,7 +348,8 @@ let timeout = """
     state, SweetAlert.Run(errorAlert)
 """
 
-let confirmAlertMsg = """
+let confirmAlertMsg =
+    """
 | ConfirmAlertMsg ->
     // map user action to application message, whether they confirm the dialog or not
     // if the dialog is dismissed, you can handle each dismissal reason
@@ -372,7 +389,8 @@ let confirmAlertMsg = """
     state, SweetAlert.Run(errorAlert)
 """
 
-let customConfirmBtnText = """
+let customConfirmBtnText =
+    """
 | CustomConfirmBtnText ->
     let alert =
         SimpleAlert("We are going to launch the missiles")
@@ -383,7 +401,8 @@ let customConfirmBtnText = """
     state, SweetAlert.Run(alert)
 """
 
-let scrollbarPaddingFalseText = """
+let scrollbarPaddingFalseText =
+    """
 | ScrollbarPaddingFalse ->
     let alert =
         SimpleAlert("A simple alert without padding")
@@ -392,7 +411,8 @@ let scrollbarPaddingFalseText = """
     state, SweetAlert.Run(alert)
 """
 
-let withImage = """
+let withImage =
+    """
 | WithImage ->
     let alert =
         SimpleAlert("Modal with a custom image.")
@@ -405,7 +425,8 @@ let withImage = """
     state, SweetAlert.Run(alert)
 """
 
-let inputAlertMsg = """
+let inputAlertMsg =
+    """
 | InputAlertMsg ->
 
     let validate input =
@@ -442,7 +463,8 @@ let inputAlertMsg = """
     state, SweetAlert.Run(errorAlert)
 """
 
-let confirmToastAlert = """
+let confirmToastAlert =
+    """
 | ConfirmToastAlertMsg ->
     let handleConfirm = function
     | ConfirmAlertResult.Confirmed -> AppMsg.ConfirmResultMsg (Ok "You confirmed")
@@ -457,7 +479,9 @@ let confirmToastAlert = """
 
     state, SweetAlert.Run(confirmAlert)
 """
-let simpleToastAlert = """
+
+let simpleToastAlert =
+    """
 | SimpleToastAlert ->
     let toastAlert =
         ToastAlert("Things about to go down")
@@ -469,7 +493,9 @@ let simpleToastAlert = """
 
     state, SweetAlert.Run(toastAlert)
 """
-let toastTopConfirm = """
+
+let toastTopConfirm =
+    """
 | ToastTopConfirm ->
     let toastAlert =
         ToastAlert("Things are going good!")
@@ -479,13 +505,17 @@ let toastTopConfirm = """
 
     state, SweetAlert.Run(toastAlert)
 """
-let closeButtonSample = """
+
+let closeButtonSample =
+    """
 Toastr.message "I have a close button"
 |> Toastr.title "Close"
 |> Toastr.showCloseButton
 |> Toastr.error
 """
-let interactive = """
+
+let interactive =
+    """
 | Interactive ->
     let cmd =
         Toastr.message "Click me to dispatch 'Clicked' message"
@@ -503,282 +533,310 @@ let interactive = """
 """
 
 let renderSimpleAlert dispatch =
-    div [ Style [ Padding 20 ] ] [
-        h3 [ ] [ str "SimpleAlert API" ]
-        p [ ] [ str "SimpleAlert lets you create highly customizable SweetAlert modals that show information. " ]
-        br [ ]
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch SimplestAlert) ]
-                    [ str "dispatch SimplestAlert" ]
-            ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ h3 [] [ str "SimpleAlert API" ]
+          p [] [ str "SimpleAlert lets you create highly customizable SweetAlert modals that show information. " ]
+          br []
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch SimplestAlert) ]
+                          [ str "dispatch SimplestAlert" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str simplestAlert ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str simplestAlert ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch SimpleAlertWithTitle) ]
-                    [ str "dispatch SimpleAlertWithTitle" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch SimpleAlertWithTitle) ]
+                          [ str "dispatch SimpleAlertWithTitle" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str simplestAlertWithTitle ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str simplestAlertWithTitle ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch SuccessAlert) ]
-                    [ str "dispatch SuccessAlert" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch SimpleAlertWithHtml) ]
+                          [ str "dispatch SimpleAlertWithHtml" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str successAlert ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str simplestAlertWithHtml ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch Timeout) ]
-                    [ str "dispatch Timeout" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch SuccessAlert) ]
+                          [ str "dispatch SuccessAlert" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str timeout ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str successAlert ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch HideConfirm) ]
-                    [ str "dispatch HideConfirm" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch Timeout) ] [ str "dispatch Timeout" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str hideConfirm ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str timeout ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch WithImage) ]
-                    [ str "dispatch WithImage" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch HideConfirm) ]
+                          [ str "dispatch HideConfirm" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str withImage ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str hideConfirm ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch CustomConfirmBtnText) ]
-                    [ str "dispatch CustomConfirmBtnText" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch WithImage) ]
+                          [ str "dispatch WithImage" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str customConfirmBtnText ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str withImage ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch ScrollbarPaddingFalse) ]
-                    [ str "dispatch ScrollbarPaddingFalse" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch CustomConfirmBtnText) ]
+                          [ str "dispatch CustomConfirmBtnText" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str scrollbarPaddingFalseText ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str customConfirmBtnText ] ] ] ]
 
-    ]
+          hr []
+
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch ScrollbarPaddingFalse) ]
+                          [ str "dispatch ScrollbarPaddingFalse" ] ]
+
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str scrollbarPaddingFalseText ] ] ] ]
+
+          ]
 
 let renderToastAlert dispatch =
-    div [ Style [ Padding 20 ] ] [
-        h3 [ ] [ str "ToastAlert API" ]
-        p [ ] [ str "ToastAlert lets you create modals that look and act like notification toasts" ]
-        br [ ]
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch SimpleToastAlert) ]
-                    [ str "dispatch SimpleToastAlert" ]
-            ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ h3 [] [ str "ToastAlert API" ]
+          p [] [ str "ToastAlert lets you create modals that look and act like notification toasts" ]
+          br []
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch SimpleToastAlert) ]
+                          [ str "dispatch SimpleToastAlert" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str simpleToastAlert ] ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str simpleToastAlert ] ] ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch ToastTopConfirm) ]
-                    [ str "dispatch ToastTopConfirm" ]
-            ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch ToastTopConfirm) ]
+                          [ str "dispatch ToastTopConfirm" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str toastTopConfirm ] ]
-            ]
-        ]
-    ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str toastTopConfirm ] ] ] ] ]
 
 
 let renderConfirmAlert dispatch =
-    div [ Style [ Padding 20 ] ] [
-        h3 [ ] [ str "ConfirmAlert API" ]
-        p [ ] [ str "ConfirmAlert lets create modals that have both \"OK\" and \"Cancel\" buttons and be able to dispatch messages based on the action the user takes." ]
-        p [ ] [ str "The following example demonstrates the whole story" ]
-        br [ ]
-        div [ ClassName "row"; ] [
-            div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                div [ ClassName "btn btn-info";
-                      OnClick (fun _ -> dispatch ConfirmAlertMsg ) ]
-                    [ str "dispatch ConfirmAlertMsg" ]
-            ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ h3 [] [ str "ConfirmAlert API" ]
+          p
+              []
+              [ str
+                    "ConfirmAlert lets create modals that have both \"OK\" and \"Cancel\" buttons and be able to dispatch messages based on the action the user takes." ]
+          p [] [ str "The following example demonstrates the whole story" ]
+          br []
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch ConfirmAlertMsg) ]
+                          [ str "dispatch ConfirmAlertMsg" ] ]
 
-            div [ ClassName "col-md-9" ] [
-                code [ ] [ pre [ ] [ str confirmAlertMsg ] ]
-            ]
-        ]
-    ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str confirmAlertMsg ] ] ] ] ]
 
 
 let renderInputAlert dispatch =
-        div [ Style [ Padding 20 ] ] [
-            h3 [ ] [ str "InputAlert API" ]
-            p [ ] [ str "InputAlert lets create modals that have textual input with validation capabilities, along with the \"OK\" and \"Cancel\" buttons. "]
-            br [ ]
-            div [ ClassName "row"; ] [
-                div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                    div [ ClassName "btn btn-info";
-                          OnClick (fun _ -> dispatch InputAlertMsg ) ]
-                        [ str "dispatch InputAlertMsg" ]
-                ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ h3 [] [ str "InputAlert API" ]
+          p
+              []
+              [ str
+                    "InputAlert lets create modals that have textual input with validation capabilities, along with the \"OK\" and \"Cancel\" buttons. " ]
+          br []
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch InputAlertMsg) ]
+                          [ str "dispatch InputAlertMsg" ] ]
 
-                div [ ClassName "col-md-9" ] [
-                    code [ ] [ pre [ ] [ str inputAlertMsg ] ]
-                ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str inputAlertMsg ] ] ] ] ]
 
 let renderSelectAlert dispatch =
-        div [ Style [ Padding 20 ] ] [
-            h3 [ ] [ str "SelectAlert API" ]
-            p [ ] [ str "SelectAlert lets create modals where the user can select from a dropdown. Like InputAlert, it also has validation capabilities, along with the \"OK\" and \"Cancel\" buttons. "]
-            br [ ]
-            div [ ClassName "row"; ] [
-                div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                    div [ ClassName "btn btn-info";
-                          OnClick (fun _ -> dispatch SelectAlertMsg ) ]
-                        [ str "dispatch SelectAlertMsg" ]
-                ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ h3 [] [ str "SelectAlert API" ]
+          p
+              []
+              [ str
+                    "SelectAlert lets create modals where the user can select from a dropdown. Like InputAlert, it also has validation capabilities, along with the \"OK\" and \"Cancel\" buttons. " ]
+          br []
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch SelectAlertMsg) ]
+                          [ str "dispatch SelectAlertMsg" ] ]
 
-                div [ ClassName "col-md-9" ] [
-                    code [ ] [ pre [ ] [ str selectAlertMsg ] ]
-                ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str selectAlertMsg ] ] ] ] ]
 
 let renderConfirmToastAlert dispatch =
-        div [ Style [ Padding 20 ] ] [
-            h3 [ ] [ str "ConfirmToastAlert API" ]
-            p [ ] [ str "Combines ConfirmAlert with ToastAlert functionality"]
-            br [ ]
-            div [ ClassName "row"; ] [
-                div [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ] [
-                    div [ ClassName "btn btn-info";
-                          OnClick (fun _ -> dispatch ConfirmToastAlertMsg ) ]
-                        [ str "dispatch ConfirmToastAlertMsg" ]
-                ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ h3 [] [ str "ConfirmToastAlert API" ]
+          p [] [ str "Combines ConfirmAlert with ToastAlert functionality" ]
+          br []
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName "col-md-3"; Style [ PaddingTop 20 ] ]
+                    [ div
+                          [ ClassName "btn btn-info"; OnClick(fun _ -> dispatch ConfirmToastAlertMsg) ]
+                          [ str "dispatch ConfirmToastAlertMsg" ] ]
 
-                div [ ClassName "col-md-9" ] [
-                    code [ ] [ pre [ ] [ str confirmToastAlert ] ]
-                ]
-            ]
-        ]
+                div [ ClassName "col-md-9" ] [ code [] [ pre [] [ str confirmToastAlert ] ] ] ] ]
 
 let render state dispatch =
     let currentDocs =
-      match state with
-      | SimpleAlertDocs -> renderSimpleAlert dispatch
-      | ToastAlertDocs -> renderToastAlert dispatch
-      | ConfirmAlertDocs -> renderConfirmAlert dispatch
-      | InputAlertDocs -> renderInputAlert dispatch
-      | SelectAlertDocs -> renderSelectAlert dispatch
-      | ConfirmToastAlertDocs -> renderConfirmToastAlert dispatch
-      | _ -> h1 [ ] [ str "Unknown API" ]
+        match state with
+        | SimpleAlertDocs -> renderSimpleAlert dispatch
+        | ToastAlertDocs -> renderToastAlert dispatch
+        | ConfirmAlertDocs -> renderConfirmAlert dispatch
+        | InputAlertDocs -> renderInputAlert dispatch
+        | SelectAlertDocs -> renderSelectAlert dispatch
+        | ConfirmToastAlertDocs -> renderConfirmToastAlert dispatch
+        | _ -> h1 [] [ str "Unknown API" ]
 
-    div [ Style [ Padding 20 ] ] [
-        span [ ] [
-            h2 [ ] [ str "Elmish.SweetAlert docs" ]
-            a [ Href "https://sweetalert2.github.io/" ] [ str "SweetAlert2" ]
-            str " integration in Fable, made with <Heart /> by "
-            a [ Href "https://github.com/Zaid-Ajaj" ] [ str "Zaid-Ajaj" ]
-            str ". Implemented as Elmish commands, for installation instructions see the repo at "
-            a [ Href "https://github.com/Zaid-Ajaj/Elmish.SweetAlert" ] [ str "github." ]
-        ]
+    div
+        [ Style [ Padding 20 ] ]
+        [ span
+              []
+              [ h2 [] [ str "Elmish.SweetAlert docs" ]
+                a [ Href "https://sweetalert2.github.io/" ] [ str "SweetAlert2" ]
+                str " integration in Fable, made with <Heart /> by "
+                a [ Href "https://github.com/Zaid-Ajaj" ] [ str "Zaid-Ajaj" ]
+                str ". Implemented as Elmish commands, for installation instructions see the repo at "
+                a [ Href "https://github.com/Zaid-Ajaj/Elmish.SweetAlert" ] [ str "github." ] ]
 
-        hr [ ]
+          hr []
 
-        div [ ClassName "row" ] [
-            div [ ClassName (if state = SimpleAlertDocs then "btn btn-success" else "btn btn-secondary")
-                  OnClick (fun _ -> dispatch SwitchToSimpleAlertDocs)
-                  Style [ Height 70; Padding 20; Margin 10 ] ]
-                [ str "SimpleAlert" ]
-            div [ ClassName (if state = ToastAlertDocs then "btn btn-success" else "btn btn-secondary")
-                  OnClick (fun _ -> dispatch SwitchToToastAlertDocs)
-                  Style [ Height 70; Padding 20; Margin 10 ]  ]
-                [ str "ToastAlert" ]
-            div [ ClassName (if state = ConfirmAlertDocs then "btn btn-success" else "btn btn-secondary")
-                  OnClick (fun _ -> dispatch SwitchToConfirmAlertDocs)
-                  Style [ Height 70; Padding 20; Margin 10 ]  ]
-                [ str "ConfirmAlert" ]
-            div [ ClassName (if state = ConfirmToastAlertDocs then "btn btn-success" else "btn btn-secondary")
-                  OnClick (fun _ -> dispatch SwitchToConfirmToastAlertDocs)
-                  Style [ Height 70; Padding 20; Margin 10 ]  ]
-                [ str "ConfirmToastAlert" ]
-            div [ ClassName (if state = InputAlertDocs then "btn btn-success" else "btn btn-secondary")
-                  OnClick (fun _ -> dispatch SwitchToInputAlertDocs)
-                  Style [ Height 70; Padding 20; Margin 10 ]  ]
-                [ str "InputAlert" ]
-            div [ ClassName (if state = SelectAlertDocs then "btn btn-success" else "btn btn-secondary")
-                  OnClick (fun _ -> dispatch SwitchToSelectAlertDocs)
-                  Style [ Height 70; Padding 20; Margin 10 ]  ]
-                [ str "SelectAlert" ]
-        ]
+          div
+              [ ClassName "row" ]
+              [ div
+                    [ ClassName(
+                          if state = SimpleAlertDocs then
+                              "btn btn-success"
+                          else
+                              "btn btn-secondary"
+                      )
+                      OnClick(fun _ -> dispatch SwitchToSimpleAlertDocs)
+                      Style [ Height 70; Padding 20; Margin 10 ] ]
+                    [ str "SimpleAlert" ]
+                div
+                    [ ClassName(
+                          if state = ToastAlertDocs then
+                              "btn btn-success"
+                          else
+                              "btn btn-secondary"
+                      )
+                      OnClick(fun _ -> dispatch SwitchToToastAlertDocs)
+                      Style [ Height 70; Padding 20; Margin 10 ] ]
+                    [ str "ToastAlert" ]
+                div
+                    [ ClassName(
+                          if state = ConfirmAlertDocs then
+                              "btn btn-success"
+                          else
+                              "btn btn-secondary"
+                      )
+                      OnClick(fun _ -> dispatch SwitchToConfirmAlertDocs)
+                      Style [ Height 70; Padding 20; Margin 10 ] ]
+                    [ str "ConfirmAlert" ]
+                div
+                    [ ClassName(
+                          if state = ConfirmToastAlertDocs then
+                              "btn btn-success"
+                          else
+                              "btn btn-secondary"
+                      )
+                      OnClick(fun _ -> dispatch SwitchToConfirmToastAlertDocs)
+                      Style [ Height 70; Padding 20; Margin 10 ] ]
+                    [ str "ConfirmToastAlert" ]
+                div
+                    [ ClassName(
+                          if state = InputAlertDocs then
+                              "btn btn-success"
+                          else
+                              "btn btn-secondary"
+                      )
+                      OnClick(fun _ -> dispatch SwitchToInputAlertDocs)
+                      Style [ Height 70; Padding 20; Margin 10 ] ]
+                    [ str "InputAlert" ]
+                div
+                    [ ClassName(
+                          if state = SelectAlertDocs then
+                              "btn btn-success"
+                          else
+                              "btn btn-secondary"
+                      )
+                      OnClick(fun _ -> dispatch SwitchToSelectAlertDocs)
+                      Style [ Height 70; Padding 20; Margin 10 ] ]
+                    [ str "SelectAlert" ] ]
 
-        br [ ]
-        currentDocs
-    ]
+          br []
+          currentDocs ]
 
 Program.mkProgram init update render
 |> Program.withReactSynchronous "root"

--- a/src/ConfirmAlert.fs
+++ b/src/ConfirmAlert.fs
@@ -3,7 +3,7 @@ namespace Elmish.SweetAlert
 open Fable.Core
 
 type ConfirmAlert<'a>(text: string, handler: ConfirmAlertResult -> 'a) =
-    let config = obj()
+    let config = obj ()
 
     do
         Interop.setProp "text" text config
@@ -14,9 +14,14 @@ type ConfirmAlert<'a>(text: string, handler: ConfirmAlertResult -> 'a) =
         Interop.setProp "title" title config
         this
 
+    /// Adds HTML to the alert dialog. If text and html parameters are provided in the same time, html will be used.
+    member this.Html(html: string) =
+        Interop.setProp "html" html config
+        this
+
     /// Specify the dialog alert type.
     member this.Type(alertType: AlertType) =
-        Interop.setProp "type"  (Interop.stringifyAlertType alertType) config
+        Interop.setProp "type" (Interop.stringifyAlertType alertType) config
         this
 
     /// Shows a close button on the dialog
@@ -122,21 +127,24 @@ type ConfirmAlert<'a>(text: string, handler: ConfirmAlertResult -> 'a) =
     interface ISweetAlert<'a> with
         member this.Run(dispatch) =
             async {
-                let! result = Async.AwaitPromise (unbox (Interop.fire config))
+                let! result = Async.AwaitPromise(unbox (Interop.fire config))
                 let value = Interop.getAs<bool> result "value"
                 let handle confirmResult = dispatch (handler confirmResult)
-                if value
-                then handle ConfirmAlertResult.Confirmed
+
+                if value then
+                    handle ConfirmAlertResult.Confirmed
                 else
                     let dismiss = Interop.getAs<obj> result "dismiss"
-                    if dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "cancel"
-                    then handle (ConfirmAlertResult.Dismissed (DismissalReason.Cancel))
-                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "esc"
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.PressedEscape)
-                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "close"
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.Close)
-                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "backdrop"
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.ClickedOutsideDialog)
-                    else handle (ConfirmAlertResult.Dismissed DismissalReason.TimedOut)
+
+                    if dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "cancel" then
+                        handle (ConfirmAlertResult.Dismissed(DismissalReason.Cancel))
+                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "esc" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.PressedEscape)
+                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "close" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.Close)
+                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "backdrop" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.ClickedOutsideDialog)
+                    else
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.TimedOut)
             }
             |> Async.StartImmediate

--- a/src/ConfirmToastAlert.fs
+++ b/src/ConfirmToastAlert.fs
@@ -1,84 +1,89 @@
-namespace Elmish.SweetAlert 
+namespace Elmish.SweetAlert
 
 open Fable.Core
 
 /// Combines functionality from ConfirmAlert and ToastAlert
-type ConfirmToastAlert<'a>(text: string, handler: ConfirmAlertResult -> 'a) = 
-    let config = obj() 
+type ConfirmToastAlert<'a>(text: string, handler: ConfirmAlertResult -> 'a) =
+    let config = obj ()
 
-    do 
+    do
         Interop.setProp "text" text config
-        Interop.setProp "toast" true config 
-        Interop.setProp "showCancelButton" true config  
+        Interop.setProp "toast" true config
+        Interop.setProp "showCancelButton" true config
 
     /// Adds a title to the alert dialog.
-    member this.Title(title: string) = 
+    member this.Title(title: string) =
         Interop.setProp "title" title config
-        this 
+        this
+
+    /// Adds HTML to the alert dialog. If text and html parameters are provided in the same time, html will be used.
+    member this.Html(html: string) =
+        Interop.setProp "html" html config
+        this
 
     /// Specify the dialog alert type.
-    member this.Type(alertType: AlertType) = 
-        Interop.setProp "type"  (Interop.stringifyAlertType alertType) config
-        this 
+    member this.Type(alertType: AlertType) =
+        Interop.setProp "type" (Interop.stringifyAlertType alertType) config
+        this
 
     /// Shows a close button on the dialog
-    member this.ShowCloseButton(enable: bool) = 
-        Interop.setProp "showCloseButton" enable config 
+    member this.ShowCloseButton(enable: bool) =
+        Interop.setProp "showCloseButton" enable config
         this
 
     /// Sets whether or not the dialog shows the confirm/OK button, it is set to true by default.
-    member this.ConfirmButton(enable: bool) = 
+    member this.ConfirmButton(enable: bool) =
         Interop.setProp "showConfirmButton" enable config
         this
 
     /// Sets the text for the (OK) confirm button
-    member this.ConfirmButtonText(buttonText: string) = 
-        Interop.setProp "confirmButtonText" buttonText config 
+    member this.ConfirmButtonText(buttonText: string) =
+        Interop.setProp "confirmButtonText" buttonText config
         this
 
     /// Sets a custom class for the confirmation button, property `ButtonStyling` must be set to false.
-    member this.ConfirmButtonClass(className: string) = 
-        Interop.setProp "confirmButtonClass" className config 
+    member this.ConfirmButtonClass(className: string) =
+        Interop.setProp "confirmButtonClass" className config
         this
 
     /// Disables the default styling for the confirm buttons so you can customize it using the `ConfirmButtonClass` property
-    member this.ButtonStyling(enable: bool) = 
+    member this.ButtonStyling(enable: bool) =
         Interop.setProp "buttonsStyling" enable config
         this
 
     /// If set to true, the focus is active on the confirm button, otherwise, the cancel button gets the focus.
-    member this.FocusConfirm(enable: bool) = 
-        Interop.setProp "focusConfirm" enable config 
-        this 
+    member this.FocusConfirm(enable: bool) =
+        Interop.setProp "focusConfirm" enable config
+        this
 
     /// Sets the color for the cancel button
-    member this.CancelButtonColor(color: string) = 
-        Interop.setProp "cancelButtonColor" color config 
-        this 
+    member this.CancelButtonColor(color: string) =
+        Interop.setProp "cancelButtonColor" color config
+        this
 
     /// Sets a custom class for the cancel button, the property `ButtonStyling` must be set to false
-    member this.CancelButtonClass(className: string) = 
-        Interop.setProp "cancelButtonClass" className config 
-        this 
+    member this.CancelButtonClass(className: string) =
+        Interop.setProp "cancelButtonClass" className config
+        this
 
-    /// Sets the text of the cancel button 
-    member this.CancelButtonText(buttonText: string) = 
+    /// Sets the text of the cancel button
+    member this.CancelButtonText(buttonText: string) =
         Interop.setProp "cancelButtonText" buttonText config
         this
 
     /// Sets the color for the confirm button
-    member this.ConfirmButtonColor(color: string) = 
-        Interop.setProp "confirmButtonColor" color config 
-        this 
+    member this.ConfirmButtonColor(color: string) =
+        Interop.setProp "confirmButtonColor" color config
+        this
 
     /// Sets the position of the dialog
-    member this.Position(pos: AlertPosition) = 
+    member this.Position(pos: AlertPosition) =
         Interop.setProp "position" (Interop.stringifyPosition pos) config
         this
 
-    /// Closes the dialog after the given total of milliseconds. 
-    member this.Timeout(ms: int) = 
-        Interop.setProp "timer" ms config 
+    /// Closes the dialog after the given total of milliseconds.
+    member this.Timeout(ms: int) =
+        Interop.setProp "timer" ms config
         this
 
     /// Sets a custom class for the dialog
@@ -87,32 +92,37 @@ type ConfirmToastAlert<'a>(text: string, handler: ConfirmAlertResult -> 'a) =
         this
 
     /// Sets whether the dialog uses animation or not, it is set to true by default.
-    member this.UseAnimation(enable: bool) = 
-        Interop.setProp "animation" enable config 
-        this 
+    member this.UseAnimation(enable: bool) =
+        Interop.setProp "animation" enable config
+        this
 
     /// If set to true, the cancel button becomes focussed when the modal appears. This is set to false by default
-    member this.FocusCancel(enable: bool) = 
-        Interop.setProp "focusCancel" enable config 
-        this 
+    member this.FocusCancel(enable: bool) =
+        Interop.setProp "focusCancel" enable config
+        this
 
-    interface ISweetAlert<'a> with 
-        member this.Run(dispatch) = 
+    interface ISweetAlert<'a> with
+        member this.Run(dispatch) =
             async {
-                let! result = Async.AwaitPromise (unbox (Interop.fire config)) 
-                let value = Interop.getAs<bool> result "value"  
+                let! result = Async.AwaitPromise(unbox (Interop.fire config))
+                let value = Interop.getAs<bool> result "value"
                 let handle confirmResult = dispatch (handler confirmResult)
-                if value then handle ConfirmAlertResult.Confirmed
-                else 
-                    let dismiss = Interop.getAs<obj> result "dismiss" 
-                    if dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "cancel" 
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.Cancel)
-                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "esc" 
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.PressedEscape)
-                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "close" 
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.Close)
-                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "backdrop" 
-                    then handle (ConfirmAlertResult.Dismissed DismissalReason.ClickedOutsideDialog)
-                    else handle (ConfirmAlertResult.Dismissed DismissalReason.TimedOut)
 
-            } |> Async.StartImmediate
+                if value then
+                    handle ConfirmAlertResult.Confirmed
+                else
+                    let dismiss = Interop.getAs<obj> result "dismiss"
+
+                    if dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "cancel" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.Cancel)
+                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "esc" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.PressedEscape)
+                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "close" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.Close)
+                    elif dismiss = Interop.getAs<obj> (Interop.getAs<obj> Interop.swal "DismissReason") "backdrop" then
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.ClickedOutsideDialog)
+                    else
+                        handle (ConfirmAlertResult.Dismissed DismissalReason.TimedOut)
+
+            }
+            |> Async.StartImmediate

--- a/src/SimpleAlert.fs
+++ b/src/SimpleAlert.fs
@@ -4,7 +4,7 @@ open Fable.Core.JS
 
 /// SimpleAlert lets you create highly customizable SweetAlert modals that show information.
 type SimpleAlert<'a>(text: string) =
-    let config = obj()
+    let config = obj ()
     do Interop.setProp "text" text config
 
     /// Adds a title to the alert dialog.
@@ -12,9 +12,14 @@ type SimpleAlert<'a>(text: string) =
         Interop.setProp "title" title config
         this
 
+    /// Adds HTML to the alert dialog. If text and html parameters are provided in the same time, html will be used.
+    member this.Html(html: string) =
+        Interop.setProp "html" html config
+        this
+
     /// Specify the dialog alert type.
     member this.Type(alertType: AlertType) =
-        Interop.setProp "type"  (Interop.stringifyAlertType alertType) config
+        Interop.setProp "type" (Interop.stringifyAlertType alertType) config
         this
 
     /// Sets whether or not the dialog shows the confirm/OK button, it is set to true by default.
@@ -88,5 +93,4 @@ type SimpleAlert<'a>(text: string) =
         this
 
     interface ISweetAlert<'a> with
-        member this.Run (dispatch) =
-            Interop.fire config |> ignore
+        member this.Run(dispatch) = Interop.fire config |> ignore

--- a/src/ToastAlert.fs
+++ b/src/ToastAlert.fs
@@ -1,53 +1,57 @@
-namespace Elmish.SweetAlert 
+namespace Elmish.SweetAlert
 
 /// ToastAlert lets you create SweetAlert modals the look and act like toasts.
 type ToastAlert<'a>(text: string) =
-    let config = obj()
+    let config = obj ()
 
-    do 
-        Interop.setProp "toast" true config 
-        Interop.setProp "text" text config 
+    do
+        Interop.setProp "toast" true config
+        Interop.setProp "text" text config
 
-    /// Sets the title for the toast. 
-    member this.Title(title: string) = 
-        Interop.setProp "title" title config 
+    /// Sets the title for the toast.
+    member this.Title(title: string) =
+        Interop.setProp "title" title config
         this
 
-    /// Closes the dialog after the given total of milliseconds. 
-    member this.Timeout(ms: int) = 
-        Interop.setProp "timer" ms config 
+    /// Adds HTML to the alert dialog. If text and html parameters are provided in the same time, html will be used.
+    member this.Html(html: string) =
+        Interop.setProp "html" html config
+        this
+
+    /// Closes the dialog after the given total of milliseconds.
+    member this.Timeout(ms: int) =
+        Interop.setProp "timer" ms config
         this
 
     /// Sets whether or not the dialog shows the confirm/OK button, it is set to true by default.
-    member this.ConfirmButton(enable: bool) = 
+    member this.ConfirmButton(enable: bool) =
         Interop.setProp "showConfirmButton" enable config
         this
 
     /// Sets the text for the (OK) confirm button
-    member this.ConfirmButtonText(buttonText: string) = 
-        Interop.setProp "confirmButtonText" buttonText config 
+    member this.ConfirmButtonText(buttonText: string) =
+        Interop.setProp "confirmButtonText" buttonText config
         this
 
     /// Sets the color for the confirm button
-    member this.ConfirmButtonColor(color: string) = 
-        Interop.setProp "confirmButtonColor" color config 
-        this 
+    member this.ConfirmButtonColor(color: string) =
+        Interop.setProp "confirmButtonColor" color config
+        this
 
     /// Specify the dialog alert type.
-    member this.Type(alertType: AlertType) = 
-        Interop.setProp "type"  (Interop.stringifyAlertType alertType) config
-        this 
+    member this.Type(alertType: AlertType) =
+        Interop.setProp "type" (Interop.stringifyAlertType alertType) config
+        this
 
     /// Sets the position of the dialog
-    member this.Position(pos: AlertPosition) = 
+    member this.Position(pos: AlertPosition) =
         Interop.setProp "position" (Interop.stringifyPosition pos) config
         this
 
     /// Hides the OK (confirm) button from the dialog.
-    member this.HideConfirmButton() = 
-        Interop.setProp "showConfirmButton" false config 
+    member this.HideConfirmButton() =
+        Interop.setProp "showConfirmButton" false config
         this
 
-    interface ISweetAlert<'a> with 
-        member this.Run(dispatch) : unit = 
-            Interop.fire config |> ignore 
+    interface ISweetAlert<'a> with
+        member this.Run(dispatch) : unit = Interop.fire config |> ignore


### PR DESCRIPTION
Probably not the desired implementation but this works... from the docs (https://sweetalert2.github.io/#download)

`A HTML description for the popup.
If text and html parameters are provided in the same time, html will be used.
[Security] SweetAlert2 does NOT sanitize this parameter. It is the developer's responsibility to escape any user input when using the html option, so XSS attacks would be prevented.`